### PR TITLE
handle migrations that specify a limit on integer columns

### DIFF
--- a/lib/arjdbc/mssql/schema_statements.rb
+++ b/lib/arjdbc/mssql/schema_statements.rb
@@ -96,6 +96,42 @@ module ActiveRecord
           quote_name_part(name.to_s)
         end
 
+        # @private these cannot specify a limit
+        NO_LIMIT_TYPES = %w( text binary boolean date datetime )
+
+        def type_to_sql(type, limit = nil, precision = nil, scale = nil)
+          type_s = type.to_s
+          # MSSQL's NVARCHAR(n | max) column supports either a number between 1 and
+          # 4000, or the word "MAX", which corresponds to 2**30-1 UCS-2 characters.
+          #
+          # It does not accept NVARCHAR(1073741823) here, so we have to change it
+          # to NVARCHAR(MAX), even though they are logically equivalent.
+          #
+          # MSSQL Server 2000 is skipped here because I don't know how it will behave.
+          #
+          # See: http://msdn.microsoft.com/en-us/library/ms186939.aspx
+          if type_s == 'string' && limit == 1073741823 && ! sqlserver_2000?
+            'NVARCHAR(MAX)'
+          elsif NO_LIMIT_TYPES.include?(type_s)
+            super(type)
+          elsif type_s == 'integer' || type_s == 'int'
+            if limit.nil? || limit == 4
+              'int'
+            elsif limit == 2
+              'smallint'
+            elsif limit == 1
+              'tinyint'
+            else
+              'bigint'
+            end
+          elsif type_s == 'uniqueidentifier'
+            type_s
+          else
+            super
+          end
+        end
+
+
         private
 
         # Implements the quoting style for SQL Server


### PR DESCRIPTION
- just copied type_to_sql method directly from pre-rails5 mssql adapter.
- mssql row_locking_test.rb will now pass.