### PR TITLE
Fix image columns

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -388,7 +388,7 @@ module ActiveRecord
         # Deprecated SQL Server types.
         map.register_type 'text',  MSSQL::Type::Text.new
         map.register_type 'ntext', MSSQL::Type::Ntext.new
-        map.register_type 'image', MSSQL::Type::Image.new
+        map.register_type 'image', MSSQL::Type::VarbinaryMax.new
       end
     end
   end

--- a/lib/arjdbc/mssql/schema_statements.rb
+++ b/lib/arjdbc/mssql/schema_statements.rb
@@ -6,7 +6,7 @@ module ActiveRecord
         NATIVE_DATABASE_TYPES = {
           # Logical Rails types to SQL Server types
           primary_key:   'bigint NOT NULL IDENTITY(1,1) PRIMARY KEY',
-          integer:       { name: 'int', limit: 4 },
+          integer:       { name: 'bigint', limit: 8 },
           boolean:       { name: 'bit' },
           decimal:       { name: 'decimal' },
           float:         { name: 'float' },
@@ -175,7 +175,7 @@ module ActiveRecord
           elsif NO_LIMIT_TYPES.include?(type)
             super(type)
           elsif %i[int integer].include?(type)
-            if limit.nil? || limit == 4
+            if limit == 4
               'int'
             elsif limit == 2
               'smallint'


### PR DESCRIPTION
When using MSSQL::Type::Image columns updates to this column always bring an error like "The conversion from UNKNOWN to UNKNOWN is unsupported."

I have a JRuby on Rails application which ran very long with Rails 4.2 (quite well) and now we are upgrading it to 5.2.
Every time when we do an update on a "binary" column (which has the "image" type in the database), we get the error:
```ruby
[10] pry(main)> Draft.columns_hash[ "data" ]
=> #<ActiveRecord::ConnectionAdapters::MSSQLColumn:0x4ffa078d
 @collation=nil,
 @comment=nil,
 @default=nil,
 @default_function=nil,
 @name="data",
 @null=true,
 @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x42238078 @limit=2147483647, @precision=nil, @scale=nil, @sql_type="image", @type=:image>,
 @table_name="drafts">
[11] pry(main)> d.data = "test"
=> "test"
[12] pry(main)> d.save!
DEBUG - 2019-10-17 09:44:35 (:83629:2026):    (1.4ms)  BEGIN TRANSACTION
DEBUG - 2019-10-17 09:44:35 (:83629:2026):   Draft Update (2.1ms)  UPDATE [drafts] SET [data] = ?, [updated_at] = ?, [lock_version] = ? WHERE [drafts].[id] = ? AND [drafts].[lock_version] = ?  [["data", "<4 bytes of binary data>"], ["updated_at", 2019-10-17 07:44:35 UTC], ["lock_version", 11], ["id", 192], ["lock_version", 10]]
DEBUG - 2019-10-17 09:44:35 (:83629:2026):    (2.2ms)  ROLLBACK TRANSACTION
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: com.microsoft.sqlserver.jdbc.SQLServerException: Die Konvertierung von "UNKNOWN" in "UNKNOWN" wird nicht unterstützt.: UPDATE [drafts] SET [data] = ?, [updated_at] = ?, [lock_version] = ? WHERE [drafts].[id] = ? AND [drafts].[lock_version] = ?
from arjdbc/jdbc/RubyJdbcConnection.java:983:in `execute_prepared_update'
Caused by ActiveRecord::JDBCError: com.microsoft.sqlserver.jdbc.SQLServerException: Die Konvertierung von "UNKNOWN" in "UNKNOWN" wird nicht unterstützt.
from arjdbc/jdbc/RubyJdbcConnection.java:983:in `execute_prepared_update'
Caused by Java::ComMicrosoftSqlserverJdbc::SQLServerException: Die Konvertierung von "UNKNOWN" in "UNKNOWN" wird nicht unterstützt.
from com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDriverError(SQLServerException.java:234)
```

After changing the type map, the code runs:
```ruby
[2] pry(main)> Draft.columns_hash["data"]
=> #<ActiveRecord::ConnectionAdapters::MSSQLColumn:0x63eea8c4
 @collation=nil,
 @comment=nil,
 @default=nil,
 @default_function=nil,
 @name="data",
 @null=true,
 @sql_type_metadata=#<ActiveRecord::ConnectionAdapters::SqlTypeMetadata:0x19924f15 @limit=2147483647, @precision=nil, @scale=nil, @sql_type="image", @type=:binary>,
 @table_name="drafts">
[3] pry(main)> d.data = "test"
=> "test"
[4] pry(main)> d.save!
DEBUG - 2019-10-17 09:48:17 (:84219:2026):    (2.5ms)  BEGIN TRANSACTION
DEBUG - 2019-10-17 09:48:17 (:84219:2026):   Draft Update (8.2ms)  UPDATE [drafts] SET [updated_at] = ?, [data] = ?, [lock_version] = ? WHERE [drafts].[id] = ? AND [drafts].[lock_version] = ?  [["updated_at", 2019-10-17 07:48:17 UTC], ["data", "<4 bytes of binary data>"], ["lock_version", 11], ["id", 192], ["lock_version", 10]]
DEBUG - 2019-10-17 09:48:17 (:84219:2026):    (10.1ms)  COMMIT TRANSACTION
=> true
```