### PR TITLE
SG: Use DB timezone when setting time bindings

### DIFF
--- a/lib/arjdbc/abstract/core.rb
+++ b/lib/arjdbc/abstract/core.rb
@@ -65,6 +65,8 @@ module ArJdbc
             binds.map do |bind|
               if bind.respond_to?(:value_for_database)
                 bind.value_for_database
+              elsif bind.is_a?(Time)
+                time_for_database(bind)
               else
                 bind
               end

--- a/lib/arjdbc/abstract/quoting.rb
+++ b/lib/arjdbc/abstract/quoting.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ArJdbc
+  module Abstract
+    module Quoting
+
+      # Helper to get local/UTC time (based on `ActiveRecord::default_timezone`).
+      def time_for_database(value)
+        get = ::ActiveRecord.default_timezone == :utc ? :getutc : :getlocal
+        value.respond_to?(get) ? value.send(get) : value
+      end
+    end
+  end
+end

--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -16,6 +16,7 @@ require 'arjdbc/abstract/core'
 require 'arjdbc/abstract/connection_management'
 require 'arjdbc/abstract/database_statements'
 require 'arjdbc/abstract/transaction_support'
+require 'arjdbc/abstract/quoting'
 
 module ActiveRecord
   module ConnectionAdapters
@@ -43,6 +44,7 @@ module ActiveRecord
       include ArJdbc::Abstract::ConnectionManagement
       include ArJdbc::Abstract::DatabaseStatements
       include ArJdbc::Abstract::TransactionSupport
+      include ArJdbc::Abstract::Quoting
 
       attr_reader :prepared_statements
 

--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -14,6 +14,7 @@ require 'arjdbc/abstract/connection_management'
 require 'arjdbc/abstract/database_statements'
 require 'arjdbc/abstract/statement_cache'
 require 'arjdbc/abstract/transaction_support'
+require 'arjdbc/abstract/quoting'
 
 require 'arjdbc/mssql/utils'
 require 'arjdbc/mssql/server_version'
@@ -46,6 +47,7 @@ module ActiveRecord
       # include ArJdbc::Abstract::DatabaseStatements
       # include ArJdbc::Abstract::StatementCache
       include ArJdbc::Abstract::TransactionSupport
+      include ArJdbc::Abstract::Quoting
       include ArJdbc::MSSQLConfig
 
       include MSSQL::Quoting

--- a/lib/arjdbc/mssql/quoting.rb
+++ b/lib/arjdbc/mssql/quoting.rb
@@ -90,7 +90,7 @@ module ActiveRecord
         # The JDBC drivers does not work with 6 digits microseconds
         def quoted_date(value)
           if value.acts_like?(:time)
-            value = time_with_db_timezone(value)
+            value = time_for_database(value)
           end
 
           result = value.to_fs(:db)
@@ -143,22 +143,6 @@ module ActiveRecord
         # @private
         # @see #quote in old adapter
         BLOB_VALUE_MARKER = "''"
-
-        private
-
-        def time_with_db_timezone(value)
-          zone_conv_method = if ActiveRecord.default_timezone == :utc
-                               :getutc
-                             else
-                               :getlocal
-                             end
-
-          if value.respond_to?(zone_conv_method)
-            value = value.send(zone_conv_method)
-          else
-            value
-          end
-        end
       end
     end
   end

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -10,6 +10,7 @@ require 'arjdbc/abstract/connection_management'
 require 'arjdbc/abstract/database_statements'
 require 'arjdbc/abstract/statement_cache'
 require 'arjdbc/abstract/transaction_support'
+require 'arjdbc/abstract/quoting'
 
 require "arjdbc/mysql/adapter_hash_config"
 
@@ -34,6 +35,7 @@ module ActiveRecord
       # NOTE: do not include MySQL::DatabaseStatements
       include ArJdbc::Abstract::StatementCache
       include ArJdbc::Abstract::TransactionSupport
+      include ArJdbc::Abstract::Quoting
 
       include ArJdbc::MySQL
       include ArJdbc::MysqlConfig
@@ -137,7 +139,7 @@ module ActiveRecord
         return "EXPLAIN" if options.empty?
 
         explain_clause = "EXPLAIN #{options.join(" ").upcase}"
-        
+
         if analyze_without_explain? && explain_clause.include?("ANALYZE")
           explain_clause.sub("EXPLAIN ", "")
         else

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -19,6 +19,8 @@ require 'arjdbc/abstract/connection_management'
 require 'arjdbc/abstract/database_statements'
 require 'arjdbc/abstract/statement_cache'
 require 'arjdbc/abstract/transaction_support'
+require 'arjdbc/abstract/quoting'
+
 require 'arjdbc/postgresql/base/array_decoder'
 require 'arjdbc/postgresql/base/array_encoder'
 require 'arjdbc/postgresql/name'
@@ -864,6 +866,7 @@ module ActiveRecord::ConnectionAdapters
     include ArJdbc::Abstract::DatabaseStatements
     include ArJdbc::Abstract::StatementCache
     include ArJdbc::Abstract::TransactionSupport
+    include ArJdbc::Abstract::Quoting
     include ArJdbc::PostgreSQLConfig
 
     # NOTE: after AR refactor quote_column_name became class and instance method

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -6,6 +6,8 @@ require "arjdbc/abstract/core"
 require "arjdbc/abstract/database_statements"
 require 'arjdbc/abstract/statement_cache'
 require "arjdbc/abstract/transaction_support"
+require "arjdbc/abstract/quoting"
+
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/sqlite3/explain_pretty_printer"
@@ -846,6 +848,7 @@ module ActiveRecord::ConnectionAdapters
     include ArJdbc::Abstract::DatabaseStatements
     include ArJdbc::Abstract::StatementCache
     include ArJdbc::Abstract::TransactionSupport
+    include ArJdbc::Abstract::Quoting
 
 
     ##

--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -2445,7 +2445,7 @@ public class RubyJdbcConnection extends RubyObject {
             value = valueForDatabase(context, attribute);
         } else if (timeZoneClass.isInstance(attribute)) {
             type = jdbcTypeFor("timestamp");
-            value = attribute;
+            value = timeForDatabase(context, attribute);
         } else {
             type = jdbcTypeForPrimitiveAttribute(context, attribute);
             value = attribute;
@@ -3684,6 +3684,10 @@ public class RubyJdbcConnection extends RubyObject {
 
     protected IRubyObject valueForDatabase(final ThreadContext context, final IRubyObject attribute) {
         return attribute.callMethod(context, "value_for_database");
+    }
+
+    protected IRubyObject timeForDatabase(final ThreadContext context, final IRubyObject attribute) {
+        return adapter.callMethod(context, "time_for_database", attribute);
     }
 
     // FIXME: This should not be static and will be exposed via api in connection as instance method.

--- a/test/simple.rb
+++ b/test/simple.rb
@@ -847,6 +847,16 @@ module SimpleTestMethods
     assert_equal 'bar?', entry.content
   end
 
+  def test_time_bind_param
+    with_timezone_config default: :utc, zone: 'Australia/Melbourne' do
+      time = Time.zone.local(2000, 1, 1, 16)
+      entry = Entry.create! updated_on: time + 1.hour
+      sql = 'updated_on >= ?'
+      entries = Entry.where(sql, time)
+      assert_equal 1, entries.size
+    end
+  end
+
   class ChangeEntriesTable < ActiveRecord::Migration[4.2]
     def self.up
       change_table :entries do |t|


### PR DESCRIPTION
Time objects are being sent with the initialised timezone instead of DB timezone, leading to query inconsistencies or wrong time offsets.
### Ruby
```
Workflow.where("effective_date <= ?", Time.current).last
SELECT "workflows".* FROM "workflows" WHERE (effective_date <= $1) ORDER BY "workflows"."id" DESC LIMIT $2  [[nil, "2025-09-18 03:11:44.998672"], ["LIMIT", 1]
```
### JRuby
```
Workflow.where("effective_date <= ?", Time.current).last
Workflow Load (109.1ms)  SELECT "workflows".* FROM "workflows" WHERE (effective_date <= ?) ORDER BY "workflows"."id" DESC LIMIT ?  [[nil, Tue, 09 Sep 2025 15:02:41.133000000 AEST +10:00], ["LIMIT", 1]]
```

TODO:
Couple log bindings with execution bindings as they are decoupled misleading final queries.


SPEC needed to cover this scenario.  however additional specs in the application should be needed to check app behaviour